### PR TITLE
Adding new export formats. 

### DIFF
--- a/MvcReportViewer/ReportFormat.cs
+++ b/MvcReportViewer/ReportFormat.cs
@@ -5,6 +5,12 @@
         Excel,
         Word,
         Pdf,
-        Image
+        Image,
+        ExcelOpenXml,
+        WordOpenXml,
+        MHtml,
+        Atom,
+        Csv,
+        Xml
     }
 }

--- a/MvcReportViewer/ReportRunner.cs
+++ b/MvcReportViewer/ReportRunner.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Reporting.WebForms;
+﻿using System;
+using Microsoft.Reporting.WebForms;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Linq;
@@ -150,6 +151,13 @@ namespace MvcReportViewer
                         var reportDataSource = new ReportDataSource(dataSource.Key, dataSource.Value);
                         localReport.DataSources.Add(reportDataSource);
                     }
+                }
+
+                var formats = new LocalReport().ListRenderingExtensions();
+
+                if (!formats.Any(x => String.Compare(x.Name, ReportFormat.ToString() , StringComparison.OrdinalIgnoreCase) == 0))
+                {
+                    throw new MvcReportViewerException("Local Server doesn't support the format specified." );
                 }
 
                 Warning[] warnings;


### PR DESCRIPTION
I ran into the problem that the MvcReportViewer Excel export format its using the older version  2003 (.xls) and not to the new Excel new format (.xlsx) (besides of another advantages like size for example https://msdn.microsoft.com/en-us/library/aa338205%28v=office.12%29.aspx?f=255&MSPPError=-2147217396)

Then I decided to modify and add more export formats to your list, testing on local (Checking that support the specified format) and SSRS servers without any problem. 

Maybe someone else might need, my two cents to this great tool.

Ivan Paniagua Monroy
MCTS-MCSD-MCSA