### PR TITLE
Added .gitattributes files to make cycling changes without overwriting original connection strings easier.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+MvcReportViewerExample/Web.config merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-MvcReportViewerExample/Web.config merge=ours

--- a/MvcReportViewerExample/.gitattributes
+++ b/MvcReportViewerExample/.gitattributes
@@ -1,0 +1,1 @@
+Web.config merge=ours

--- a/MvcReportViewerTests/.gitattributes
+++ b/MvcReportViewerTests/.gitattributes
@@ -1,0 +1,1 @@
+TestData.cs merge=ours

--- a/MvcReportViewerTests/.gitattributes
+++ b/MvcReportViewerTests/.gitattributes
@@ -1,1 +1,2 @@
+App.config merge=ours
 TestData.cs merge=ours


### PR DESCRIPTION
The SSRS connection in the original project uses a named instance located at:
http://localhost/ReportServer_SQLEXPRESS

While my local SSRS connection is at port 60002 on the default instance:
http://localhost:60002/ReportServer

In order to test effectively, I have to update all of my local connection strings in order to connect to a live SSRS server when running the example project or unit tests. This means I have to remember NOT to update Web.config or TestData.cs when merging to a branch I intend to use for a pull request. Otherwise, I will feel like a bad citizen.

To work around this annoyance, I have added two .gitattribute files: One for the Example project and one for the Test project. These files will cause Git to merge the Web.config and TestData.cs files with a user-defined "ours" merge strategy, if one exists in the user's .gitconfig file. Otherwise, the default merge strategy will be used.  [For more information on .gitattributes and the merge attribute, look here](http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Merge-Strategies).

The result is that anyone wishing to contribute to the project is now free to define an "ours" merge strategy in their local .gitconfig and not worry about updating their local connection strings. When merging back from local branches, the local connection strings will be discarded, along with any other changes to those two files.