### PR TITLE
Export filename and export format types

### DIFF
--- a/MvcReportViewer/ControlSettings.cs
+++ b/MvcReportViewer/ControlSettings.cs
@@ -263,5 +263,11 @@ namespace MvcReportViewer
         /// </summary>
         [UriParameter("_42")]
         public int? AsyncPostBackTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display name of the report.
+        /// </summary>
+        [UriParameter("_43")]
+        public string DisplayName { get; set; }
     }
 }

--- a/MvcReportViewer/ControlSettings.cs
+++ b/MvcReportViewer/ControlSettings.cs
@@ -269,5 +269,11 @@ namespace MvcReportViewer
         /// </summary>
         [UriParameter("_43")]
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Specifies the export formats to be visible. All export formats will be visible if the value is null or empty.
+        /// </summary>
+        [UriParameter("_44")]
+        public ReportFormat[] VisibleExportFormats { get; set; }
     }
 }

--- a/MvcReportViewer/ControlSettingsManager.cs
+++ b/MvcReportViewer/ControlSettingsManager.cs
@@ -64,6 +64,10 @@ namespace MvcReportViewer
                                                         .ToArgb()
                                                         .ToString(CultureInfo.CurrentCulture);
                 }
+                else if (property.PropertyType == typeof(ReportFormat[]))
+                {
+                    serializedSetting = string.Join(",", (IEnumerable<ReportFormat>) value);
+                }
                 else
                 {
                     serializedSetting = value.ToString();
@@ -160,6 +164,18 @@ namespace MvcReportViewer
                 {
                     property.SetValue(settings, mode, null);
                 }
+            }
+            else if (property.PropertyType == typeof(ReportFormat[]))
+            {
+                var hiddenFormats = new List<ReportFormat>();
+                foreach (var splitValue in value.Split(new[] {","}, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    ReportFormat format;
+                    if (Enum.TryParse(splitValue, true, out format))
+                        hiddenFormats.Add(format);
+                }
+
+                property.SetValue(settings, hiddenFormats.ToArray(), null);
             }
             else
             {

--- a/MvcReportViewer/ReportViewerExtensions.cs
+++ b/MvcReportViewer/ReportViewerExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Reflection;
 using Microsoft.Reporting.WebForms;
 using System.Web.UI.WebControls;
 
@@ -92,6 +94,11 @@ namespace MvcReportViewer
             {
                 localReport.DisplayName = parameters.ControlSettings.DisplayName;
             }
+
+            if (parameters.ControlSettings?.VisibleExportFormats != null)
+            {
+                HideRenderingExtensions(localReport, parameters.ControlSettings);
+            }
         }
 
         private static void SetupRemoteProcessing(ReportViewer reportViewer, ReportViewerParameters parameters)
@@ -131,6 +138,28 @@ namespace MvcReportViewer
             if (parameters.ControlSettings?.DisplayName != null)
             {
                 serverReport.DisplayName = parameters.ControlSettings.DisplayName;
+            }
+
+            if (parameters.ControlSettings?.VisibleExportFormats != null)
+            {
+                HideRenderingExtensions(serverReport, parameters.ControlSettings);
+            }
+        }
+
+        private static void HideRenderingExtensions(Report report, ControlSettings controlSettings)
+        {
+            var hiddenRenderingExtensions = report.ListRenderingExtensions()
+                    .Where(renderingExtension =>
+                        controlSettings.VisibleExportFormats.All(exportFormat =>
+                            !renderingExtension.Name.EqualsIgnoreCase(exportFormat.ToString())));
+
+            foreach (var renderingExtension in hiddenRenderingExtensions)
+            {
+                var isVisiblePrivateField = renderingExtension.GetType().GetField("m_isVisible", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (isVisiblePrivateField != null)
+                {
+                    isVisiblePrivateField.SetValue(renderingExtension, false);
+                }
             }
         }
 

--- a/MvcReportViewer/ReportViewerExtensions.cs
+++ b/MvcReportViewer/ReportViewerExtensions.cs
@@ -87,7 +87,11 @@ namespace MvcReportViewer
                     localReport.DataSources.Add(dataSource);
                 }
             }
-            
+
+            if (parameters.ControlSettings?.DisplayName != null)
+            {
+                localReport.DisplayName = parameters.ControlSettings.DisplayName;
+            }
         }
 
         private static void SetupRemoteProcessing(ReportViewer reportViewer, ReportViewerParameters parameters)
@@ -122,6 +126,11 @@ namespace MvcReportViewer
             if (parameters.ReportParameters.Count > 0)
             {
                 serverReport.SetParameters(parameters.ReportParameters.Values);
+            }
+
+            if (parameters.ControlSettings?.DisplayName != null)
+            {
+                serverReport.DisplayName = parameters.ControlSettings.DisplayName;
             }
         }
 


### PR DESCRIPTION
Resolves #162.
Resolves #144.

This is what we're currently using at my company. With #144, a decision was made to specify the export format types to display rather than the types to hide because it is more useful to us to specify it that way.

Happy to take any feedback.